### PR TITLE
Update docker command

### DIFF
--- a/examples/GPT-NeoXT-Chat-Base-20B/README.md
+++ b/examples/GPT-NeoXT-Chat-Base-20B/README.md
@@ -18,5 +18,5 @@ docker build . -t openchatkit-service:latest
 ## Start service
 
 ```bash
-docker run -it --rm --p 50051:50051 --gpus all openchatkit-service:latest
+docker run -it --rm -p 50051:50051 --gpus all openchatkit-service:latest
 ```

--- a/examples/alpaca-lora-7B/README.md
+++ b/examples/alpaca-lora-7B/README.md
@@ -13,5 +13,5 @@ docker build . -t alpaca-7b-service:latest
 ## Start service
 
 ```bash
-docker run -it --rm --p 50051:50051 --gpus all alpaca-7b-service:latest
+docker run -it --rm -p 50051:50051 --gpus all alpaca-7b-service:latest
 ```

--- a/examples/sentence-transformers/README.md
+++ b/examples/sentence-transformers/README.md
@@ -18,5 +18,5 @@ docker build . -t openchatkit-service:latest
 ## Start service
 
 ```bash
-docker run -it --rm --p 50051:50051 --gpus all openchatkit-service:latest
+docker run -it --rm -p 50051:50051 --gpus all openchatkit-service:latest
 ```


### PR DESCRIPTION
The original command used the flag `--p` to publish the container's port to the host, but the correct flag is `-p`. This small change ensures that the container's port is properly exposed and accessible.