### PR TITLE
Adding completion example with mpt-7b-storywriter

### DIFF
--- a/examples/MPT-7B-Storywriter-65kplus/Dockerfile
+++ b/examples/MPT-7B-Storywriter-65kplus/Dockerfile
@@ -1,0 +1,37 @@
+FROM nvidia/cuda:11.7.1-devel-ubuntu20.04
+
+# Update, install
+ENV PY_VERSION='3.9'
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y software-properties-common
+RUN add-apt-repository -y ppa:deadsnakes/ppa
+RUN apt update
+RUN apt install -y build-essential python${PY_VERSION} git
+RUN apt install -y python3-pip python3-distutils python3-packaging
+RUN apt install -y python3-dev
+RUN python${PY_VERSION} -m pip install --upgrade pip setuptools wheel
+
+# Create user instead of using root
+ENV USER='user'
+RUN groupadd -r user && useradd -r -g $USER $USER
+USER $USER
+
+# Define workdir
+WORKDIR /home/$USER/app
+
+# Prevent Python from buffering `stdout` and `stderr`
+ENV PYTHONBUFFERED 1
+
+# Install project
+COPY . .
+RUN python${PY_VERSION} -m pip install -r requirements.txt
+
+# Get model weights and tokenizer
+RUN python${PY_VERSION} get_models.py
+
+# Publish port
+EXPOSE 50051:50051
+
+# Enjoy
+ENTRYPOINT python${PY_VERSION} server.py
+CMD ["--address", "[::]:50051"]

--- a/examples/MPT-7B-Storywriter-65kplus/README.md
+++ b/examples/MPT-7B-Storywriter-65kplus/README.md
@@ -1,0 +1,42 @@
+# MosaicML's MPT-7B-StoryWriter-65k+ (4-bit quantization)
+
+## Description
+
+This example shows how to use the [MPT-7B-StoryWriter-65k+ model](https://huggingface.co/mosaicml/mpt-7b-storywriter), with a [SimpleAI](https://github.com/lhenault/simpleAI) server.
+
+It implements `complete` method.
+
+## Setup
+
+First build the image with:
+
+```bash
+docker build . -t mpt-7b-storywriter:0.1
+```
+
+Then declare your model in your *SimpleAI* configuration file `models.toml`:
+
+```toml
+[mpt-7b-storywriter]
+    [mpt-7b-storywriter.metadata]
+        owned_by    = 'MosaicML'
+        permission  = []
+        description = 'MPT-7B-StoryWriter-65k+ is a model designed to read and write fictional stories with super long context lengths. It was built by finetuning MPT-7B with a context length of 65k tokens on a filtered fiction subset of the books3 dataset. At inference time, thanks to ALiBi, MPT-7B-StoryWriter-65k+ can extrapolate even beyond 65k tokens.'
+    [mpt-7b-storywriter.network]
+        type = 'gRPC'
+        url = 'localhost:50051'
+```
+
+## Start service
+
+Just start your container with:
+
+```bash
+docker run -it --rm -p 50051:50051 --gpus all mpt-7b-storywriter:0.1
+```
+
+And start your *SimpleAI* instance, for instance with:
+
+```bash
+simple_ai serve [--host 127.0.0.1] [--port 8080]
+```

--- a/examples/MPT-7B-Storywriter-65kplus/get_models.py
+++ b/examples/MPT-7B-Storywriter-65kplus/get_models.py
@@ -1,0 +1,18 @@
+import logging
+
+MODEL_ID = "mosaicml/mpt-7b-storywriter"
+
+if __name__ == "__main__":
+    from huggingface_hub import snapshot_download
+    from transformers.utils import move_cache
+
+    for repo_id in (MODEL_ID,):
+        try:
+            snapshot_download(repo_id)
+        except Exception as ex:
+            logging.exception(f"Could not retrieve {repo_id}: {ex}")
+
+    try:
+        move_cache()
+    except Exception as ex:
+        logging.exception(f"Could not migrate cache: {ex}")

--- a/examples/MPT-7B-Storywriter-65kplus/model.py
+++ b/examples/MPT-7B-Storywriter-65kplus/model.py
@@ -1,0 +1,99 @@
+import logging
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+from get_models import MODEL_ID
+from simple_ai.api.grpc.chat.server import LanguageModel
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, StoppingCriteria
+
+
+@dataclass
+class StopOnTokens(StoppingCriteria):
+    stop_token_ids: Optional[Union[list, tuple]]
+
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> bool:
+        for stop_id in self.stop_token_ids:
+            if input_ids[0][-1] == stop_id:
+                return True
+        return False
+
+
+# Model:
+# - Has been trained with a sequence length of 2048
+# - Fine tuned with a sequence length of 65536 (thanks to ALiBi)
+# - Can use a higher sequence length at inferernce (thanks to ALiBi)
+# Note: ALiBi is only implemented with torch and triton attention.
+MAX_SEQUENCE_LENGTH = 65536
+
+
+@dataclass(unsafe_hash=True)
+class CompletionModel(LanguageModel):
+    gpu_id: int = 0
+    device = torch.device("cuda", gpu_id)
+    tokenizer = AutoTokenizer.from_pretrained(
+        MODEL_ID, model_max_length=MAX_SEQUENCE_LENGTH, truncation_side="left"
+    )
+    config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+    # Attention: either "torch" (default), "flash" or "triton"
+    config.attn_config["attn_impl"] = "torch"
+    config.update({"max_seq_len": MAX_SEQUENCE_LENGTH})
+
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_ID,
+        config=config,
+        torch_dtype=torch.bfloat16,
+        trust_remote_code=True,
+    ).to(device)
+
+    def complete(
+        self,
+        prompt: str = "<|endoftext|>",
+        max_tokens: int = 512,
+        temperature: float = 0.6,
+        end_of_text: Union[str, list, tuple] = ("<|endoftext|>",),
+        *args,
+        **kwargs,
+    ) -> str:
+        try:
+            if isinstance(end_of_text, str):
+                end_of_text = (end_of_text,)
+
+            logging.info(f"Input prompt:\n{prompt}")
+            inputs = self.tokenizer(
+                prompt, return_tensors="pt", truncation=True, max_length=MAX_SEQUENCE_LENGTH // 2
+            ).to(self.model.device)
+
+            # Use Torch's Flash attention
+            with torch.backends.cuda.sdp_kernel(
+                enable_flash=True, enable_math=False, enable_mem_efficient=False
+            ):
+                outputs = self.model.generate(
+                    **inputs,
+                    max_new_tokens=max_tokens,
+                    do_sample=True,
+                    temperature=temperature,
+                    pad_token_id=self.tokenizer.eos_token_id,
+                )
+                output = self.tokenizer.batch_decode(outputs)[0]
+                logging.info(f"Model output:\n{output}")
+
+                # Remove the context from the output
+                output = output[len(prompt) :]
+
+                # Stop if end of text
+                for item in end_of_text:
+                    if item in output:
+                        output = output.split(item)[0]
+                    break
+
+                # Avoid issues with GPU vRAM
+                del inputs
+                torch.cuda.empty_cache()
+
+                return output
+        except Exception as ex:
+            logging.exception(ex)
+
+        return ""

--- a/examples/MPT-7B-Storywriter-65kplus/requirements-optional.txt
+++ b/examples/MPT-7B-Storywriter-65kplus/requirements-optional.txt
@@ -1,0 +1,3 @@
+# You need CUDA available to build flash-attn
+flash-attn
+triton

--- a/examples/MPT-7B-Storywriter-65kplus/requirements.txt
+++ b/examples/MPT-7B-Storywriter-65kplus/requirements.txt
@@ -1,0 +1,7 @@
+einops
+accelerate
+bitsandbytes
+sentencepiece
+torch
+transformers
+simple_ai_server>=0.2.1

--- a/examples/MPT-7B-Storywriter-65kplus/server.py
+++ b/examples/MPT-7B-Storywriter-65kplus/server.py
@@ -1,0 +1,24 @@
+import logging
+
+from model import CompletionModel as Model
+from simple_ai.api.grpc.completion.server import (
+    LanguageModelServicer as CompletionServicer,
+    serve,
+)
+
+if __name__ == "__main__":
+    import argparse
+
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--address", type=str, default="[::]:50051")
+    args = parser.parse_args()
+
+    logging.info(f"Starting gRPC server on {args.address}")
+    completion_servicer = CompletionServicer(model=Model())
+
+    serve(
+        address=args.address,
+        model_servicer=completion_servicer,
+    )


### PR DESCRIPTION
Following the example based on `mpt-7b-chat` for `/completions/chat` endpoint, I'm adding an example of the "basic" `/completions` using `mpt-7b-Storywriter-65k+` model from [MosaicML](https://www.mosaicml.com/blog/mpt-7b).

Tagging @urbien again because of his expressed interest for this one (although it's **not** the 4-bit quantized version).